### PR TITLE
Update Python range to >= 3.9, per 3.8 EOL

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ license_files =
 [options]
 include_package_data = true
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 
 [options.extras_require]
 testing =


### PR DESCRIPTION
This version-reference was missed in `f7a6d64`.